### PR TITLE
[codex] Preserve Ghostty terminal behavior over SSH

### DIFF
--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -4,6 +4,11 @@ window-height = 40
 macos-option-as-alt = true
 link-url = true
 
+# Keep Ghostty's terminal capabilities usable when SSH'ing to hosts that do not
+# already know xterm-ghostty. This avoids remote zsh prompt/redraw glitches while
+# preserving Ghostty's richer terminfo when the remote host can install it.
+shell-integration-features = cursor,no-sudo,title,ssh-env,ssh-terminfo,path
+
 # Send Shift+Enter as CSI-u so TUIs such as Codex can distinguish it from Enter.
 keybind = shift+enter=csi:13;2u
 keybind = global:cmd+s=toggle_quick_terminal

--- a/tests/test_dotfiles.bats
+++ b/tests/test_dotfiles.bats
@@ -118,6 +118,10 @@ EOF
     grep -q '^link-url = true$' "$DOTFILES_DIR/config/ghostty/config"
 }
 
+@test "ghostty enables SSH terminal compatibility helpers" {
+    grep -q '^shell-integration-features = .*ssh-env.*ssh-terminfo' "$DOTFILES_DIR/config/ghostty/config"
+}
+
 @test "tmux URL opener normalizes plain links safely" {
     local fake_bin="$TEST_TMPDIR/fake-bin"
     local opened_url="$TEST_TMPDIR/opened-url"


### PR DESCRIPTION
## Summary

- Enable Ghostty `ssh-env` and `ssh-terminfo` shell-integration features.
- Add a Bats regression check so the SSH terminal compatibility helpers remain enabled.

## Why

Direct SSH from Ghostty can expose `TERM=xterm-ghostty` to a remote macOS host that does not know Ghostty's terminfo. That can make zsh/oh-my-posh redraw incorrectly, producing doubled or weird letters. Starting tmux first masks the issue because tmux changes the advertised terminal to `tmux-256color`.

## Impact

Ghostty can now install its terminfo on SSH targets when possible, and use safer SSH terminal environment behavior when needed, while preserving Ghostty-specific capabilities for hosts that support them.

## Validation

- `ghostty +validate-config --config-file="$PWD/config/ghostty/config"`
- `bats tests/test_dotfiles.bats --filter 'ghostty|SSH terminal compatibility'`
- `make test-bats`
- `make lint`

## Not tested

- Manual SSH reproduction from the other Mac; user will validate that path.